### PR TITLE
Check the module layout exists or not

### DIFF
--- a/modules/mod_k2_content/mod_k2_content.php
+++ b/modules/mod_k2_content/mod_k2_content.php
@@ -52,5 +52,7 @@ $items = modK2ContentHelper::getItems($params);
 
 if (count($items))
 {
-    require (JModuleHelper::getLayoutPath('mod_k2_content', $getTemplate.DS.'default'));
+    $file = JModuleHelper::getLayoutPath('mod_k2_content', $getTemplate.DS.'default');
+    if(file_exists($file))
+        require ($file);
 }


### PR DESCRIPTION
PHP Fatal error:  require(): Failed opening required '/var/www/modules/mod_k2_content/tmpl/default.php' (include_path='.:/usr/share/pear:/usr/share/php') in /var/www/modules/mod_k2_content/mod_k2_content.php on line 55