### PR TITLE
To have extra fields available for related items

### DIFF
--- a/components/com_k2/models/item.php
+++ b/components/com_k2/models/item.php
@@ -179,7 +179,8 @@ class K2ModelItem extends K2Model
 		}
 
 		//Extra fields
-		if (($view == 'item' && $item->params->get('itemExtraFields')) || ($view == 'itemlist' && ($task == '' || $task == 'category') && $item->params->get('catItemExtraFields')) || ($view == 'itemlist' && $task == 'tag' && $item->params->get('tagItemExtraFields')) || ($view == 'itemlist' && ($task == 'search' || $task == 'date') && $item->params->get('genericItemExtraFields')))
+		//Modified by Mohamed Adbelaziz to have extra fields available for related items
+		if ((($view == 'item' || $view == 'relatedByTag') && $item->params->get('itemExtraFields')) || ($view == 'itemlist' && ($task == '' || $task == 'category') && $item->params->get('catItemExtraFields')) || ($view == 'itemlist' && $task == 'tag' && $item->params->get('tagItemExtraFields')) || ($view == 'itemlist' && ($task == 'search' || $task == 'date') && $item->params->get('genericItemExtraFields')))
 		{
 			$item->extra_fields = $this->getItemExtraFields($item->extra_fields, $item);
 		}


### PR DESCRIPTION
This is to make extra fields available to be accessed using the alias based method in the related items section of the item view page.